### PR TITLE
권순호 10주차 구현사항

### DIFF
--- a/src/main/java/team1/BE/seamless/DTO/MemberRequestDTO.java
+++ b/src/main/java/team1/BE/seamless/DTO/MemberRequestDTO.java
@@ -17,7 +17,7 @@ public class MemberRequestDTO {
         @NotBlank(message = "이메일은 필수 입력 사항입니다.")
         private String email;
 
-        private String code;
+        private String attendURL;
 
         private String name;
 
@@ -28,9 +28,9 @@ public class MemberRequestDTO {
         public CreateMember() {
         }
 
-        public CreateMember(String email, String code, String name) {
+        public CreateMember(String email, String attendURL, String name) {
             this.email = email;
-            this.code = code;
+            this.attendURL = attendURL;
             this.name = name;
         }
 
@@ -38,8 +38,8 @@ public class MemberRequestDTO {
             return email;
         }
 
-        public String getCode() {
-            return code;
+        public String getattendURL() {
+            return attendURL;
         }
     }
 

--- a/src/main/java/team1/BE/seamless/DTO/MemberRequestDTO.java
+++ b/src/main/java/team1/BE/seamless/DTO/MemberRequestDTO.java
@@ -25,6 +25,10 @@ public class MemberRequestDTO {
             return name;
         }
 
+        public String getAttendURL() {
+            return attendURL;
+        }
+
         public CreateMember() {
         }
 
@@ -38,9 +42,6 @@ public class MemberRequestDTO {
             return email;
         }
 
-        public String getattendURL() {
-            return attendURL;
-        }
     }
 
     public static class UpdateMember {

--- a/src/main/java/team1/BE/seamless/DTO/MemberRequestDTO.java
+++ b/src/main/java/team1/BE/seamless/DTO/MemberRequestDTO.java
@@ -11,48 +11,6 @@ public class MemberRequestDTO {
 
     }
 
-//    public static class CreateMember {
-//
-//        @NotBlank(message = "이름은 필수 입력 사항입니다.")
-//        @Size(max = 15, message = "이름은 공백 포함 최대 15글자까지 가능합니다.")
-//        private String name;
-//
-//        private String role;
-//
-//        @Email(message = "유효한 이메일 주소를 입력해주세요.")
-//        @NotBlank(message = "이메일은 필수 입력 사항입니다.")
-//        private String email;
-//
-//        private String imageURL;
-//
-//
-//        public CreateMember() {
-//        }
-//
-//        public CreateMember(String name, String role, String email, String imageURL) {
-//            this.name = name;
-//            this.role = role;
-//            this.email = email;
-//            this.imageURL = imageURL;
-//        }
-//
-//        public String getName() {
-//            return name;
-//        }
-//
-//        public String getRole() {
-//            return role;
-//        }
-//
-//        public String getEmail() {
-//            return email;
-//        }
-//
-//        public String getImageURL() {
-//            return imageURL;
-//        }
-//    }
-
     public static class CreateMember {
 
         @Email(message = "유효한 이메일 주소를 입력해주세요.")

--- a/src/main/java/team1/BE/seamless/DTO/MemberResponseDTO.java
+++ b/src/main/java/team1/BE/seamless/DTO/MemberResponseDTO.java
@@ -10,7 +10,7 @@ public class MemberResponseDTO {
 
     private String email;
 
-    private String code;
+    private String attendURL;
 
     public MemberResponseDTO(String message, String name, String role, String email) {
         this.message = message;
@@ -19,12 +19,12 @@ public class MemberResponseDTO {
         this.email = email;
     }
 
-    public MemberResponseDTO(String message, String name, String role, String email, String code) {
+    public MemberResponseDTO(String message, String name, String role, String email, String attendURL) {
         this.message = message;
         this.name = name;
         this.role = role;
         this.email = email;
-        this.code = code;
+        this.attendURL = attendURL;
     }
 
     public String getRole() {
@@ -59,7 +59,7 @@ public class MemberResponseDTO {
         this.message = message;
     }
 
-    public String getCode() {
-        return code;
+    public String getattendURL() {
+        return attendURL;
     }
 }

--- a/src/main/java/team1/BE/seamless/Team1BeApplication.java
+++ b/src/main/java/team1/BE/seamless/Team1BeApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
 @EnableJpaAuditing
+@EnableScheduling
 public class Team1BeApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/team1/BE/seamless/controller/AttendUrlController.java
+++ b/src/main/java/team1/BE/seamless/controller/AttendUrlController.java
@@ -25,10 +25,11 @@ public class AttendUrlController {
     /**
      * 팉장의 토큰과 프로젝트id로 프로젝트 존재 검증 프로젝트id + " " + exp로 코드 생성 코드를 양방향 암호화 ex)
      */
-    @Operation(summary = "팀원초대 코드 생성")
-    @PostMapping("/api/project/{projectId}/invite-link")
+    @Operation(summary = "팀원초대 링크 생성(참여코드 아님)")
+    @PostMapping("/api/project/{projectId}/invite-link/{userId}")
     public SingleResult<String> generateInviteLink(HttpServletRequest req,
-        @Valid @PathVariable("projectId") Long projectId) {
-        return new SingleResult<>(attendURLService.generateAttendURL(req, projectId));
+                                                   @Valid @PathVariable("projectId") Long projectId,
+                                                   @Valid @PathVariable("userId") Long userId) {
+        return new SingleResult<>(attendURLService.generateAttendURL(req, projectId, userId));
     }
 }

--- a/src/main/java/team1/BE/seamless/controller/InviteCodeByEmailController.java
+++ b/src/main/java/team1/BE/seamless/controller/InviteCodeByEmailController.java
@@ -27,7 +27,7 @@ public class InviteCodeByEmailController {
     @PostMapping("/invite")
     public SingleResult<String> inviteMemberToProject(@RequestBody InviteRequestDTO inviteRequest) {
         try {
-            inviteService.sendProjectInvite(inviteRequest.getEmail(), inviteRequest.getProjectId());
+            inviteService.sendProjectInvite(inviteRequest.getEmail(), inviteRequest.getProjectId(), inviteRequest.getName());
             return new SingleResult<>("팀원의 이메일로 프로젝트 초대코드 전송이 성공적으로 처리되었습니다.");
         } catch (Exception e) {
             throw new BaseHandler(HttpStatus.BAD_REQUEST,"이메일로 프로젝트 초대코드 전송이 실패되었습니다. : " + e.getMessage());

--- a/src/main/java/team1/BE/seamless/entity/MemberEntity.java
+++ b/src/main/java/team1/BE/seamless/entity/MemberEntity.java
@@ -19,13 +19,6 @@ public class MemberEntity extends BaseEntity {
 
     }
 
-//    public MemberEntity(String name, String role, String email, String imageURL) {
-//        this.name = name;
-//        this.role = role;
-//        this.email = email;
-//        this.imageURL = imageURL;
-//    }
-
     public MemberEntity(String name, String role, String email, String imageURL,
         ProjectEntity projectEntity) {//Task 오류나서 생성자 새로 만들어놓음
         this.name = name;

--- a/src/main/java/team1/BE/seamless/mapper/MemberMapper.java
+++ b/src/main/java/team1/BE/seamless/mapper/MemberMapper.java
@@ -43,12 +43,12 @@ public class MemberMapper {
                 memberEntity.getEmail());
     }
 
-    public MemberResponseDTO toCreateResponseDTO(MemberEntity memberEntity, String code) {
+    public MemberResponseDTO toCreateResponseDTO(MemberEntity memberEntity, String attendURL) {
         return new MemberResponseDTO("성공적으로 생성되었습니다.",
                 memberEntity.getName(),
                 memberEntity.getRole(),
                 memberEntity.getEmail(),
-                code);
+                attendURL);
     }
 
     public MemberResponseDTO toPutResponseDTO(MemberEntity memberEntity) {

--- a/src/main/java/team1/BE/seamless/repository/ProjectRepository.java
+++ b/src/main/java/team1/BE/seamless/repository/ProjectRepository.java
@@ -1,5 +1,6 @@
 package team1.BE.seamless.repository;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -23,4 +24,5 @@ public interface ProjectRepository extends JpaRepository<ProjectEntity, Long> {
 
     Optional<ProjectEntity> findByIdAndUserEntityIdAndIsDeletedFalse(Long projectId, Long userId);
 
+    List<ProjectEntity> findAllByIsDeletedFalse();
 }

--- a/src/main/java/team1/BE/seamless/service/AttendURLService.java
+++ b/src/main/java/team1/BE/seamless/service/AttendURLService.java
@@ -20,8 +20,6 @@ public class AttendURLService {
     private final ParsingPram parsingPram;
     private final AesEncrypt aesEncrypt;
 
-    private static final String BASE_URL = "https://seamless.com/attend"; // 기본 URL 설정
-
     @Autowired
     public AttendURLService(ProjectRepository projectRepository, ParsingPram parsingPram,
         AesEncrypt aesEncrypt) {
@@ -45,13 +43,11 @@ public class AttendURLService {
         }
 
 
+//        참여 링크를 URL 형식으로 내려줄 필요가 없음. code랑 비슷한 형식으로 내려주면 프론트쪽에서 URL 형식으로 바꿔줄거임
 //        참여 링크는 프로젝트id + exp로 구성
 //        exp는 1일로 가정
-        String code = aesEncrypt.encrypt(
-            project.getId() + "_" + project.getStartDate().withNano(0));
-        // URL 조립
-        String attendURL = String.format("%s?projectId=%d&code=%s", BASE_URL, projectId, code);
-
+        String attendURL = aesEncrypt.encrypt(
+                project.getId() + "_" + LocalDateTime.now().plusDays(1).withNano(0));
         return attendURL;
     }
 

--- a/src/main/java/team1/BE/seamless/service/AttendURLService.java
+++ b/src/main/java/team1/BE/seamless/service/AttendURLService.java
@@ -20,6 +20,8 @@ public class AttendURLService {
     private final ParsingPram parsingPram;
     private final AesEncrypt aesEncrypt;
 
+    private static final String BASE_URL = "https://seamless.com/attend"; // 기본 URL 설정
+
     @Autowired
     public AttendURLService(ProjectRepository projectRepository, ParsingPram parsingPram,
         AesEncrypt aesEncrypt) {
@@ -43,11 +45,14 @@ public class AttendURLService {
         }
 
 
-//        코드는 프로젝트id + exp로 구성
+//        참여 링크는 프로젝트id + exp로 구성
 //        exp는 1일로 가정
         String code = aesEncrypt.encrypt(
-            project.getId() + "_" + LocalDateTime.now().plusDays(1).withNano(0));
-        return code;
+            project.getId() + "_" + project.getStartDate().withNano(0));
+        // URL 조립
+        String attendURL = String.format("%s?projectId=%d&code=%s", BASE_URL, projectId, code);
+
+        return attendURL;
     }
 
 }

--- a/src/main/java/team1/BE/seamless/service/AttendURLService.java
+++ b/src/main/java/team1/BE/seamless/service/AttendURLService.java
@@ -1,7 +1,5 @@
 package team1.BE.seamless.service;
 
-import static team1.BE.seamless.util.URL.DEFAULTURL;
-
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.time.LocalDateTime;
@@ -30,17 +28,17 @@ public class AttendURLService {
         this.aesEncrypt = aesEncrypt;
     }
 
-    public String generateAttendURL(HttpServletRequest req, Long projectId) {
-        ProjectEntity project = projectRepository.findByIdAndUserEntityEmailAndIsDeletedFalse(projectId,parsingPram.getEmail(req))
-            .orElseThrow(() -> new BaseHandler(HttpStatus.NOT_FOUND, "프로젝트가 존재하지 않음"));
+    public String generateAttendURL(HttpServletRequest req, @Valid Long projectId, @Valid Long userId) {
+        ProjectEntity project = projectRepository.findByIdAndUserEntityIdAndIsDeletedFalse(projectId,userId)
+                .orElseThrow(() -> new BaseHandler(HttpStatus.NOT_FOUND, "프로젝트가 존재하지 않음"));
 
-         //현재 시간이 프로젝트 종료 기한을 넘어섰는지 체크
+        //현재 시간이 프로젝트 종료 기한을 넘어섰는지 체크
         if (project.getEndDate().isBefore(LocalDateTime.now())) {
             throw new BaseHandler(HttpStatus.BAD_REQUEST, "프로젝트는 종료되었습니다.");
         }
 
         // 팀장인지 확인(팀원인지 굳이 한번 더 확인하지 않음. 팀장인지만 검증.)
-        if (parsingPram.getRole(req).equals(Role.MEMBER.toString())) {
+        if (parsingPram.getRole(req).equals(Role.USER.toString())) {
             throw new BaseHandler(HttpStatus.UNAUTHORIZED,"생성 권한이 없습니다.");
         }
 
@@ -52,8 +50,4 @@ public class AttendURLService {
         return code;
     }
 
-//    public String generateAttendURL(String projectId, String expirationDate) {
-//        String generatedUrl = "https://seamless.com/invite?code=" + UUID.randomUUID().toString() + "&project_id=" + projectId + "&expires=" + expirationDate;
-//        return generatedUrl;
-//    }
 }

--- a/src/main/java/team1/BE/seamless/service/InviteCodeByEmailService.java
+++ b/src/main/java/team1/BE/seamless/service/InviteCodeByEmailService.java
@@ -6,7 +6,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.mail.javamail.JavaMailSenderImpl;
 import org.springframework.stereotype.Service;
 import team1.BE.seamless.entity.ProjectEntity;
 import team1.BE.seamless.repository.ProjectRepository;
@@ -19,16 +18,16 @@ import java.util.UUID;
 @Service
 public class InviteCodeByEmailService {
 
-    private final JavaMailSender mailSender;
-    private final ProjectRepository projectRepository;
+    private JavaMailSender mailSender;
+    private ProjectRepository projectRepository;
 
     @Autowired
-    InviteCodeByEmailService(ProjectRepository projectRepository) {
-        this.mailSender = new JavaMailSenderImpl();
+    InviteCodeByEmailService(JavaMailSender mailSender, ProjectRepository projectRepository) {
+        this.mailSender = mailSender;
         this.projectRepository = projectRepository;
     }
 
-    public void sendProjectInvite(String email, Long projectId) {
+    public void sendProjectInvite(String email, Long projectId, String name) {
         // 프로젝트 존재 검증
         ProjectEntity project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new BaseHandler(HttpStatus.NOT_FOUND, "해당 프로젝트가 존재하지 않습니다."));
@@ -36,16 +35,16 @@ public class InviteCodeByEmailService {
         // 프로젝트 종료 기간 검증
         if (project.getEndDate().isBefore(LocalDateTime.now())) {
             throw new BaseHandler(HttpStatus.BAD_REQUEST, "프로젝트는 종료되었습니다.");
-        } // 프로젝트 initData에 EndDate 설정이 안되어있어서 지금 테스트하면 오류걸림 그래서 주석처리 해놓음ㅇㅇ
+        } 
 
-        // 팀원인지 팀장인지 검증은 필요없음.(어차피 이 post요청은 아무 권한 없는 사람이 보내는 것 취급임)
+        // 팀원인지 팀장인지 검증은 필요없음.(어차피 이 post요청은 아무 권한 없는 사람이 보내는 것이기 때문임)
 
 
         // 참여코드 생성 (UUID 기반 + 현재 시간)
         String participationCode = generateParticipationCode();
 
         // 이메일 메시지 내용 생성
-        String message = "안녕하세요,\n\n" +
+        String message = "안녕하세요,\n\n" + name + "님. " +
                 "프로젝트 '" + project.getName() + "'에 초대되었습니다.\n" +
                 "참여 코드는 다음과 같습니다: " + participationCode + "\n\n" +
                 "프로젝트에 참여하려면 초대 코드를 사용하여 입장해주세요.\n\n" +

--- a/src/main/java/team1/BE/seamless/service/MemberService.java
+++ b/src/main/java/team1/BE/seamless/service/MemberService.java
@@ -111,7 +111,7 @@ public class MemberService {
         String code = aesEncrypt.encrypt(member.getId().toString());
         System.out.println(code);
 
-//        이메일로 코드 전달(추가 요망)
+//        이메일로 코드 전달(추가 요망) -> 추가할 필요없이 프론트 쪽에서 요청을 같이 보내달라고 하면 됨.
 
         return memberMapper.toCreateResponseDTO(member, code);
     }

--- a/src/main/java/team1/BE/seamless/service/MemberService.java
+++ b/src/main/java/team1/BE/seamless/service/MemberService.java
@@ -78,13 +78,12 @@ public class MemberService {
     }
 
 
-    // 멤버 초기 데이터 때문에 오버로딩한 메서드임
     @Transactional
     public MemberResponseDTO createMember(MemberRequestDTO.CreateMember create) {
 
 //        프로젝트id, exp
-        Long projectId = Long.parseLong(aesEncrypt.decrypt(create.getCode()).split("_")[0]);
-        LocalDateTime exp = Util.parseDate(aesEncrypt.decrypt(create.getCode()).split("_")[1]);
+        Long projectId = Long.parseLong(aesEncrypt.decrypt(create.getattendURL()).split("_")[0]);
+        LocalDateTime exp = Util.parseDate(aesEncrypt.decrypt(create.getattendURL()).split("_")[1]);
 
 //        exp검사
         if (exp.isBefore(LocalDateTime.now())) {
@@ -112,7 +111,7 @@ public class MemberService {
         System.out.println(code);
 
 
-//      이메일로 코드 전달
+//      이메일로 참여코드 전달
         String email = create.getEmail();
         String message = "안녕하세요,\n\n" + create.getName() + "님. " +
                 "프로젝트 '" + project.getName() + "'에 초대되었습니다.\n" + "\n\n" +

--- a/src/main/java/team1/BE/seamless/service/MemberService.java
+++ b/src/main/java/team1/BE/seamless/service/MemberService.java
@@ -81,21 +81,22 @@ public class MemberService {
     @Transactional
     public MemberResponseDTO createMember(MemberRequestDTO.CreateMember create) {
 
-//        프로젝트id, exp
-        Long projectId = Long.parseLong(aesEncrypt.decrypt(create.getattendURL()).split("_")[0]);
-        LocalDateTime exp = Util.parseDate(aesEncrypt.decrypt(create.getattendURL()).split("_")[1]);
+        // 프로젝트 ID와 만료 시간 추출
+        String[] urlParts = aesEncrypt.decrypt(create.getAttendURL()).split("_");
+        Long projectId = Long.parseLong(urlParts[0]);
+        LocalDateTime exp = Util.parseDate(urlParts[1]);
 
-//        exp검사
+        // 만료 시간 검사
         if (exp.isBefore(LocalDateTime.now())) {
-            throw new BaseHandler(HttpStatus.FORBIDDEN,"초대 코드가 만료되었습니다.");
+            throw new BaseHandler(HttpStatus.FORBIDDEN, "초대 코드가 만료되었습니다.");
         }
 
-//       멤버 이메일 중복 여부 검사
-        if(memberRepository.findByEmailAndIsDeleteFalse(create.getEmail()).isPresent()){
-            throw new BaseHandler(HttpStatus.UNAUTHORIZED,"이메일이 중복 됩니다.");
+        // 멤버 이메일 중복 여부 검사
+        if (memberRepository.findByEmailAndIsDeleteFalse(create.getEmail()).isPresent()) {
+            throw new BaseHandler(HttpStatus.UNAUTHORIZED, "이메일이 중복 됩니다.");
         }
 
-//        프로젝트 조회
+        // 프로젝트 조회
         ProjectEntity project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new BaseHandler(HttpStatus.NOT_FOUND, "해당 프로젝트가 존재하지 않습니다."));
 
@@ -103,26 +104,27 @@ public class MemberService {
             throw new BaseHandler(HttpStatus.BAD_REQUEST, "프로젝트는 종료되었습니다.");
         }
 
+        // 멤버 생성
         MemberEntity member = memberMapper.toEntity(create, project);
         memberRepository.save(member);
 
-//        코드 생성
+        // 멤버 ID로 참여 코드 생성
         String code = aesEncrypt.encrypt(member.getId().toString());
         System.out.println(code);
 
-
-//      이메일로 참여코드 전달
+        // 이메일로 참여 코드 전달
         String email = create.getEmail();
         String message = "안녕하세요,\n\n" + create.getName() + "님. " +
                 "프로젝트 '" + project.getName() + "'에 초대되었습니다.\n" + "\n\n" +
                 "프로젝트에 참여하려면 초대 코드를 사용하여 입장해주세요.\n\n" +
-                "감사합니다.\n\n" + "참여 코드는 다음과 같습니다: \n" ;
+                "감사합니다.\n\n" + "참여 코드는 다음과 같습니다: \n" + code;
         String subject = "[프로젝트 초대] 프로젝트 '" + project.getName() + "'에 참여하세요!";
-        emailSend.sendProjectInvite(email,project.getId(), message, subject);
+        emailSend.sendProjectInvite(email, project.getId(), message, subject);
 
-
+        // 응답 DTO 생성
         return memberMapper.toCreateResponseDTO(member, code);
     }
+
 
     @Transactional
     public MemberResponseDTO updateMember(Long projectId, Long memberId, UpdateMember update, HttpServletRequest req) {

--- a/src/main/java/team1/BE/seamless/service/ProjectDeadlineReminderService.java
+++ b/src/main/java/team1/BE/seamless/service/ProjectDeadlineReminderService.java
@@ -23,7 +23,7 @@ public class ProjectDeadlineReminderService {
         this.emailSend = emailSend;
     }
 
-    // 매일 오후 4시에 실행
+    // 오후 4시에 이메일 전송함
     @Scheduled(cron = "0 0 16 * * ?")
     public void sendDeadlineReminders() {
         List<ProjectEntity> projects = projectRepository.findAllByIsDeletedFalse();

--- a/src/main/java/team1/BE/seamless/service/ProjectDeadlineReminderService.java
+++ b/src/main/java/team1/BE/seamless/service/ProjectDeadlineReminderService.java
@@ -1,0 +1,48 @@
+package team1.BE.seamless.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import team1.BE.seamless.entity.ProjectEntity;
+import team1.BE.seamless.repository.ProjectRepository;
+import team1.BE.seamless.util.Email.EmailSend;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+@Service
+public class ProjectDeadlineReminderService {
+
+    private final ProjectRepository projectRepository;
+    private final EmailSend emailSend;
+
+    @Autowired
+    public ProjectDeadlineReminderService(ProjectRepository projectRepository, EmailSend emailSend) {
+        this.projectRepository = projectRepository;
+        this.emailSend = emailSend;
+    }
+
+    // 매일 오후 4시에 실행
+    @Scheduled(cron = "0 0 16 * * ?")
+    public void sendDeadlineReminders() {
+        List<ProjectEntity> projects = projectRepository.findAllByIsDeletedFalse();
+
+        for (ProjectEntity project : projects) {
+            LocalDateTime now = LocalDateTime.now();
+            LocalDateTime endDate = project.getEndDate();
+            long daysUntilDeadline = ChronoUnit.DAYS.between(now, endDate);
+
+            // 마감일이 14일, 7일, 3일, 1일 남았을 때 이메일 전송
+            if (daysUntilDeadline == 14 || daysUntilDeadline == 7 || daysUntilDeadline == 3 || daysUntilDeadline == 1) {
+                String subject = "[프로젝트 마감 임박 알림] '" + project.getName() + "' 프로젝트";
+                String message = "안녕하세요,\n\n" +
+                        "프로젝트 '" + project.getName() + "'의 마감 기한이 " + daysUntilDeadline + "일 남았습니다.\n\n" +
+                        "프로젝트 관련 작업을 마무리해 주세요.\n\n감사합니다.";
+
+                project.getMemberEntities().forEach(member ->
+                        emailSend.sendProjectInvite(member.getEmail(), project.getId(), message, subject));
+            }
+        }
+    }
+}

--- a/src/main/java/team1/BE/seamless/util/Email/EmailSend.java
+++ b/src/main/java/team1/BE/seamless/util/Email/EmailSend.java
@@ -57,10 +57,10 @@ public class EmailSend {
         mailSender.send(mailMessage);
     }
 
-
+    // 참여 링크랑 너무 똑같을 것 같아서 EndDate를 기반으로 참여 코드 만듦.
     private String generateParticipationCode(ProjectEntity project) {
         String code = aesEncrypt.encrypt(
-                project.getId() + "_" + project.getStartDate().withNano(0));
+                project.getId() + "_" + project.getEndDate().withNano(0));
         return code;
     }
 }

--- a/src/main/java/team1/BE/seamless/util/Email/EmailSend.java
+++ b/src/main/java/team1/BE/seamless/util/Email/EmailSend.java
@@ -1,0 +1,64 @@
+package team1.BE.seamless.util.Email;
+// 팀원이 초대링크에 해당하는 페이지에서 이름, 이메일을 작성하여
+// 요청을 보낼 때의 서비스 계층
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+import team1.BE.seamless.entity.ProjectEntity;
+import team1.BE.seamless.repository.ProjectRepository;
+import team1.BE.seamless.util.errorException.BaseHandler;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+@Service
+public class EmailSend {
+
+    private JavaMailSender mailSender;
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    EmailSend(JavaMailSender mailSender, ProjectRepository projectRepository) {
+        this.mailSender = mailSender;
+        this.projectRepository = projectRepository;
+    }
+
+    public void sendProjectInvite(String email, Long projectId, String message, String subject) {
+        // 프로젝트 존재 검증
+        ProjectEntity project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new BaseHandler(HttpStatus.NOT_FOUND, "해당 프로젝트가 존재하지 않습니다."));
+
+        // 프로젝트 종료 기간 검증
+        if (project.getEndDate().isBefore(LocalDateTime.now())) {
+            throw new BaseHandler(HttpStatus.BAD_REQUEST, "프로젝트는 종료되었습니다.");
+        }
+
+        // 팀원인지 팀장인지 검증은 필요없음.(어차피 이 post요청은 아무 권한 없는 사람이 보내는 것이기 때문임)
+
+
+        // 참여코드 생성 (UUID 기반 + 현재 시간)
+        String participationCode = generateParticipationCode();
+
+        // 이메일 메시지 내용 생성
+        message += "" + participationCode;
+
+
+        SimpleMailMessage mailMessage = new SimpleMailMessage();
+        mailMessage.setTo(email);
+        mailMessage.setSubject(subject); // 이메일 제목 설정임.
+        mailMessage.setText(message);
+        mailSender.send(mailMessage);
+    }
+
+
+    private String generateParticipationCode() {
+        String uniqueId = UUID.randomUUID().toString().substring(0, 8); // 8자리 코드임
+        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmm"));
+        return uniqueId + "-" + timestamp; // 참여코드 예: 1234abcd-202410161530 와 같이 생성됨.
+        // 이렇게 시간을 기준으로 만들면, 이전 or 다른 팀장의 프로젝트의 참여코드와 겹칠 일이 없게됨.
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,6 +6,13 @@ spring.profiles.active=dev
 
 # oauth, db, mail
 spring.profiles.include=oauth, db, mail
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=${mail.username}
+spring.mail.password=${mail.password}
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true
+spring.mail.properties.mail.smtp.starttls.required=true
 
 # db
 spring.sql.init.mode=always


### PR DESCRIPTION
1. 이메일 전송 기능 요청대로 **Util로 분리**시킴
서비스 계층을 Util로 분리시키는 느낌으로 함. 컨트롤러가 삭제되고 서비스 계층의 코드를 Util로 분리시키는 느낌으로 함(다른 방안이 없다고 판단함 -> 어차피 @Service가 붙어있어서 Util이 아닌 서비스 계층에 남기는 거 염두해야할듯)
2. 이벤트에서 **이메일 독촉 전송 기능** 구현 완료함
서비스 계층에 만들어놓음. 컨트롤러 없이 서비스 계층만 있음 -> 마감기한 가까워지면 자동으로 이메일 전송되게 구현해놓음.
3. 지난 주에 동혁이가 **어텐트링크를 참여코드로 오해**하고 잘못 코딩해놓은 줄 알았으나 아니었음…여하튼 수정사항 다음과 같음. 
    1. 기존에 **참여코드** 만드는 로직은 “랜덤 문자 + 현재 날짜” 으로만 생성하는 로직이었는데, "동혁이의 **암호화 로직+프로젝트 종료 시간**(멤버가 중간에 추가되는 경우에 같은 **참여코드**를 내려줘야하는데, 현재 시간 기준으로 내려주면 **참여코드**가 변하게되어서 시작 시간으로 구성함.)" 으로 변경해놓음.
    2. 또한 **어텐트링크**와 **참여코드** 의 변수이름이 보는 사람으로 하여금 굉장한 혼란을 야기하기 때문에 다음과 같이 변경함. **어텐트링크**와 **참여코드** 모두 code라는 변수명을 사용했는데, 참여코드만 code를 사용하고, 어텐드링크는 attendURL이라는 변수명을 사용함.(팀원들끼리 구두로 이야기할 때도 **어텐트링크**와 **참여코드**로 얘기해야 서로 안 헷갈릴듯해요ㅎㅎ)

[요청사항]

4. 테스트 코드에서 MemberServiceTest랑 InviteMemberTest 수정 부탁...(제가 짠 코드가 아니라서 함부로 터치하기가 어렵습니다....)

[참고]

5. 기존에 사용하던 이메일 컨트롤러랑 이메일 서비스 테스트 겸으로 아직 삭제 안 해놓음.